### PR TITLE
trk_read support for unknown number of tracks

### DIFF
--- a/trk_read.m
+++ b/trk_read.m
@@ -54,7 +54,7 @@ iz([ix iy]) = [];
 
 % Parse in body
 if header.n_count > 0
-    max_n_trks = header.n_count;
+	max_n_trks = header.n_count;
 else
 	% Unknown number of tracks; we'll just have to read until we run out.
 	max_n_trks = inf;
@@ -90,6 +90,10 @@ while iTrk <= max_n_trks
     end
     tracks(iTrk).matrix(:,1:3) = coords;
 	iTrk = iTrk + 1;
+end
+
+if header.n_count == 0
+	header.n_count = iTrk;
 end
 
 fclose(fid);

--- a/trk_read.m
+++ b/trk_read.m
@@ -53,10 +53,25 @@ iz = 1:3;
 iz([ix iy]) = [];
 
 % Parse in body
-tracks(header.n_count).nPoints = 0;
+if header.n_count > 0
+    max_n_trks = header.n_count;
+else
+	% Unknown number of tracks; we'll just have to read until we run out.
+	max_n_trks = inf;
+end
 
-for iTrk = 1:header.n_count
-    tracks(iTrk).nPoints = fread(fid, 1, 'int');
+% It's impossible to preallocate the "tracks" variable because we don't
+% know the number of points on each curve ahead of time; we find out by
+% reading the file.  The line below suppresses preallocation warnings.
+%#ok<*AGROW>
+
+iTrk = 1;
+while iTrk <= max_n_trks
+	pts = fread(fid, 1, 'int');
+	if feof(fid)
+		break;
+	end
+    tracks(iTrk).nPoints = pts;
     tracks(iTrk).matrix  = fread(fid, [3+header.n_scalars, tracks(iTrk).nPoints], 'float')';
     if header.n_properties
         tracks(iTrk).props = fread(fid, header.n_properties, 'float');
@@ -74,6 +89,7 @@ for iTrk = 1:header.n_count
         coords(:,iy) = header.dim(iy)*header.voxel_size(iy) - coords(:,iy);
     end
     tracks(iTrk).matrix(:,1:3) = coords;
+	iTrk = iTrk + 1;
 end
 
 fclose(fid);


### PR DESCRIPTION
Hi John-

The trackvis documentation at http://trackvis.org/docs/?subsect=fileformat indicates that the n_count value in the .trk header can be zero when (for some reason) the number of tracks in the file is not stored in the header.  In this case, you just have to parse the body of the file in an online fashion, looking for an eof.  I've edited trk_read.m to support this case.  Would you consider merging this change into the master?

Thanks,
Jadrian Miles
jadrian@cs.brown.edu
jadrian.org
