### PR TITLE
Store track matrix and properties as single-precision floats, as in header

### DIFF
--- a/trk_read.m
+++ b/trk_read.m
@@ -72,9 +72,9 @@ while iTrk <= max_n_trks
 		break;
 	end
     tracks(iTrk).nPoints = pts;
-    tracks(iTrk).matrix  = fread(fid, [3+header.n_scalars, tracks(iTrk).nPoints], 'float')';
+    tracks(iTrk).matrix  = fread(fid, [3+header.n_scalars, tracks(iTrk).nPoints], '*float')';
     if header.n_properties
-        tracks(iTrk).props = fread(fid, header.n_properties, 'float');
+        tracks(iTrk).props = fread(fid, header.n_properties, '*float');
     end
     
     % Modify orientation of tracks (always LPS) to match orientation of volume


### PR DESCRIPTION
Hey again John --- When dealing with massive tractography datasets, Matlab can run short on memory.  One reason is that the coordinates of the track points are stored in Matlab as double-precision floats, though the .trk file only stores them in single precision.  A small change (storing these points in the Matlab representation as single-precision floats too) allows for half the memory footprint with no loss of precision.  I've tested this change out on my own machine and it works fine.  Would you be interested in pulling into the master?

Thanks,
Jadrian
